### PR TITLE
Strip all null entries from metadata before processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ CHANGELOG
 ------------------
 
 - Ignore blank lines before the starting `---` marker
- - Optimize Markdown parsing
- - Small logging improvements
+- Optimize Markdown parsing
+- Small logging improvements
 
 2.1.0 - 2023-06-09
 ------------------

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+- Strip all null entries from metadata to avoid returning empty tags and authors

--- a/pelican/plugins/yaml_metadata/yaml_metadata.py
+++ b/pelican/plugins/yaml_metadata/yaml_metadata.py
@@ -50,7 +50,7 @@ YAML_METADATA_PROCESSORS = {
 
 
 def _strip(obj):
-    return str(obj if obj is not None else "").strip()
+    return str(obj).strip()
 
 
 def _to_list(obj):
@@ -135,8 +135,13 @@ class YAMLMetadataReader(MarkdownReader):
         """
         output = {}
         for name, value in meta.items():
+            if value is None:
+                continue
+
             name = name.lower()
             is_list = isinstance(value, list)
+            if is_list:
+                value = [x for x in value if x is not None]
 
             if name in self.settings["FORMATTED_FIELDS"]:
                 # join mutliple formatted fields before parsing them as markdown
@@ -167,6 +172,7 @@ class YAMLMetadataReader(MarkdownReader):
             if value is not _DEL:
                 output[name] = value
 
+        __log__.debug("Parsed YAML data: %r into Pelican data %r", meta, output)
         return output
 
 


### PR DESCRIPTION
This fixes empty metadata entries producing a value of `[""]` and therefore creating invalid objects for keys that are expected to be lists (tags, authors)

Fixes #6